### PR TITLE
Feature online course (#5)

### DIFF
--- a/examples/joint_inference/online_course/big_model.py
+++ b/examples/joint_inference/online_course/big_model.py
@@ -18,7 +18,7 @@ from interface import Estimator
 
 
 def run():
-    inference_instance = BigModelService(estimator=Estimator(node_type="cloud"))
+    inference_instance = BigModelService(estimator=Estimator(is_cloud_node=True))
     inference_instance.start()
 
 

--- a/examples/joint_inference/online_course/cifar100_partition_net.py
+++ b/examples/joint_inference/online_course/cifar100_partition_net.py
@@ -1,0 +1,166 @@
+# Created by: Yerlan Idelbayev (https://github.com/akamaster/pytorch_resnet_cifar10/blob/master/resnet.py)
+# 
+# Properly implemented ResNet-s for CIFAR10 as described in paper [1].
+# 
+# The implementation and structure of this file is hugely influenced by [2]
+# which is implemented for ImageNet and doesn't have option A for identity.
+# Moreover, most of the implementations on the web is copy-paste from
+# torchvision's resnet and has wrong number of params.
+#
+# 
+# which this implementation indeed has.
+# 
+# Reference:
+# [1] Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun
+#     Deep Residual Learning for Image Recognition. arXiv:1512.03385
+# [2] https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
+# 
+# If you use this implementation in you work, please don't forget to mention the
+# author, Yerlan Idelbayev.
+
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.nn.init as init
+
+from torch.autograd import Variable
+
+__all__ = ['resnet110_p1', 'resnet110_p2', 'resnet110_p1_head']
+
+def _weights_init(m):
+    classname = m.__class__.__name__
+    if isinstance(m, nn.Linear) or isinstance(m, nn.Conv2d):
+        init.kaiming_normal_(m.weight)
+
+
+class LambdaLayer(nn.Module):
+    def __init__(self, lambd):
+        super(LambdaLayer, self).__init__()
+        self.lambd = lambd
+
+    def forward(self, x):
+        return self.lambd(x)
+
+
+class BasicBlock(nn.Module):
+    expansion = 1
+
+    def __init__(self, in_planes, planes, stride=1, option='A'):
+        super(BasicBlock, self).__init__()
+        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != planes:
+            if option == 'A':
+                """
+                For CIFAR10 ResNet paper uses option A.
+                """
+                self.shortcut = LambdaLayer(lambda x:
+                                            F.pad(x[:, :, ::2, ::2], (0, 0, 0, 0, planes//4, planes//4), "constant", 0))
+            elif option == 'B':
+                self.shortcut = nn.Sequential(
+                     nn.Conv2d(in_planes, self.expansion * planes, kernel_size=1, stride=stride, bias=False),
+                     nn.BatchNorm2d(self.expansion * planes)
+                )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+
+class ResNet110_P1(nn.Module):
+    def __init__(self, block, num_blocks):
+        super(ResNet110_P1, self).__init__()
+        self.in_planes = 16
+        self.conv1 = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(16)
+        self.layer1 = self._make_layer(block, 16, num_blocks[0], stride=1)
+        self.layer2 = self._make_layer(block, 32, num_blocks[1], stride=2)
+        self.layer3 = self._make_layer(block, 64, num_blocks[2], stride=2)
+        self.upsample = nn.Upsample(scale_factor=4, mode='nearest')
+        # self.downsample = nn.MaxPool3d((5,1,1),stride=(5,1,1))
+        self.downsample = nn.Conv2d(80, 16, kernel_size=1, stride=1, bias=False)
+        self.apply(_weights_init)
+
+    def _make_layer(self, block, planes, num_blocks, stride):
+        strides = [stride] + [1]*(num_blocks-1)
+        layers = []
+        for stride in strides:
+            layers.append(block(self.in_planes, planes, stride))
+            self.in_planes = planes * block.expansion
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        shortcut = out
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        cat = torch.cat((self.upsample(out), shortcut), 1)
+        cat = self.downsample(cat)
+        return (out, cat)
+
+
+class ResNet110_P1_Head(nn.Module):
+    def __init__(self, num_classes=100):
+        super(ResNet110_P1_Head, self).__init__()
+        self.linear = nn.Linear(64, num_classes)
+        self.apply(_weights_init)
+
+    def forward(self, x):
+        out = F.avg_pool2d(x, x.size()[3])
+        out = out.view(out.size(0), -1)
+        out = self.linear(out)
+        return out
+
+
+class ResNet110_P2(nn.Module):
+    def __init__(self, block, num_blocks, num_classes=100):
+        super(ResNet110_P2, self).__init__()
+        self.in_planes = 16
+
+        self.layer1 = self._make_layer(block, 16, num_blocks[0], stride=1)
+        self.layer2 = self._make_layer(block, 32, num_blocks[1], stride=2)
+        self.layer3 = self._make_layer(block, 64, num_blocks[2], stride=2)
+        self.linear = nn.Linear(64, num_classes)
+
+        self.apply(_weights_init)
+
+    def _make_layer(self, block, planes, num_blocks, stride):
+        strides = [stride] + [1]*(num_blocks-1)
+        layers = []
+        for stride in strides:
+            layers.append(block(self.in_planes, planes, stride))
+            self.in_planes = planes * block.expansion
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = self.layer1(x)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        out = F.avg_pool2d(out, out.size()[3])
+        out = out.view(out.size(0), -1)
+        out = self.linear(out)
+        return out
+
+
+def resnet110_p1():
+    return ResNet110_P1(BasicBlock, [3, 3, 3])
+
+
+def resnet110_p1_head(num_classes: int = 100):
+    return ResNet110_P1_Head(num_classes=num_classes)
+
+
+def resnet110_p2(num_classes: int = 100):
+    return ResNet110_P2(BasicBlock, [9, 18, 18], num_classes=num_classes)

--- a/examples/joint_inference/online_course/little_model_kaggle.py
+++ b/examples/joint_inference/online_course/little_model_kaggle.py
@@ -76,6 +76,7 @@ def main():
 
     inference_instance = JointInference(
         estimator=Estimator,
+        # estimator=Estimator(is_partitioned=True),
         hard_example_mining={
             "method": "CrossEntropy",
             "param": {
@@ -99,6 +100,7 @@ def main():
         start = time.time()
         is_hard_example, final_result, edge_result, cloud_result = (
             inference_instance.inference(image)
+            # inference_instance.inference(image, is_partitioned=True) # for partitioned inference
         )
         if get_device() == torch.device("cuda"):
             torch.cuda.current_stream().synchronize()

--- a/examples/joint_inference/online_course/online-course-big-model-deployment.yaml
+++ b/examples/joint_inference/online_course/online-course-big-model-deployment.yaml
@@ -24,7 +24,7 @@ spec:
             - name: BIG_MODEL_BIND_PORT
               value: "5000"
             - name: MODEL_URL
-              value: /data/big-model/teacher_resnet110_0.72.pt
+              value: /data/big-model/teacher_resnet110.pt;/data/big-model/resnet110_p2.pt
             - name: NAMESPACE
               value: default
             - name: SERVICE_NAME

--- a/lib/sedna/core/joint_inference/joint_inference.py
+++ b/lib/sedna/core/joint_inference/joint_inference.py
@@ -242,6 +242,9 @@ class JointInference(JobBase):
                 ClassType.CALLBACK, post_process)
 
         res = self.estimator.predict(data, **kwargs)
+        if "is_partitioned" in kwargs and kwargs["is_partitioned"]:
+            if type(res) is tuple:
+                res, data = res
         edge_result = deepcopy(res)
 
         if callback_func:


### PR DESCRIPTION
* adapted collaborative example for edge ai mooc course. Uses the trained teacher and student model on cifar100 dataset from the course

* fixed issue with numpy

* convert input image to standard array format

* extend joint inference to support partitioned inference

* implemented the joint-inference example for online course using partitioned models. The client-side small model is the frontal partition of the server-side large model.

* changed the downsampling layer of resnet110_p1 model to a conv layer.

* clean code

Co-authored-by: Haojin Yang <haojin.yang@.hpi.uni-potsdam.de>